### PR TITLE
表单Item增加Badge支持

### DIFF
--- a/examples/src/config/router.config.js
+++ b/examples/src/config/router.config.js
@@ -27,7 +27,9 @@ const asyncRouterMap = [
             meta: {
               keepAlive: true,
               icon: 'smile',
-              title: 'menu.dashboard.analysis'
+              title: 'menu.dashboard.analysis',
+              showBadge: true,
+              badgeCount: 5
             },
             component: () => import(/* webpackChunkName: "dashboard" */ '../views/dashboard/analysis')
           },
@@ -93,7 +95,9 @@ const asyncRouterMap = [
         meta: {
           keepAlive: true,
           title: 'menu.nav1',
-          icon: 'smile'
+          icon: 'smile',
+          showBadge: true,
+          badgeCount: 5
         },
         component: () => import(/* webpackChunkName: "about" */ '../views/TestPage1')
       },

--- a/examples/src/config/router.config.js
+++ b/examples/src/config/router.config.js
@@ -30,8 +30,7 @@ const asyncRouterMap = [
               title: 'menu.dashboard.analysis',
               showBadge: true,
               badge: {
-                count: 5,
-                color: '#108ee9'
+                count: 5
               }
             },
             component: () => import(/* webpackChunkName: "dashboard" */ '../views/dashboard/analysis')
@@ -46,7 +45,11 @@ const asyncRouterMap = [
               title: 'menu.dashboard.workplace',
               showBadge: true,
               badge: {
-                color: '#108ee9'
+                count: 1,
+                numberStyle: {
+                  backgroundColor: '#52c41a',
+                  color: '#999'
+                }
               }
             },
             component: () => import(/* webpackChunkName: "dashboard" */ '../views/dashboard/workplace')
@@ -113,7 +116,11 @@ const asyncRouterMap = [
         meta: {
           keepAlive: true,
           title: 'menu.nav2',
-          icon: 'smile'
+          icon: 'smile',
+          showBadge: true,
+          badge: {
+            color: 'green'
+          }
         },
         component: () => import(/* webpackChunkName: "about" */ '../views/TestPage2')
       },

--- a/examples/src/config/router.config.js
+++ b/examples/src/config/router.config.js
@@ -29,7 +29,10 @@ const asyncRouterMap = [
               icon: 'smile',
               title: 'menu.dashboard.analysis',
               showBadge: true,
-              badgeCount: 5
+              badge: {
+                count: 5,
+                color: '#108ee9'
+              }
             },
             component: () => import(/* webpackChunkName: "dashboard" */ '../views/dashboard/analysis')
           },
@@ -40,7 +43,11 @@ const asyncRouterMap = [
               global: true,
               keepAlive: true,
               icon: 'smile',
-              title: 'menu.dashboard.workplace'
+              title: 'menu.dashboard.workplace',
+              showBadge: true,
+              badge: {
+                color: '#108ee9'
+              }
             },
             component: () => import(/* webpackChunkName: "dashboard" */ '../views/dashboard/workplace')
           }
@@ -96,8 +103,7 @@ const asyncRouterMap = [
           keepAlive: true,
           title: 'menu.nav1',
           icon: 'smile',
-          showBadge: true,
-          badgeCount: 5
+          showBadge: true
         },
         component: () => import(/* webpackChunkName: "about" */ '../views/TestPage1')
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.8-22",
+    "version": "1.0.9-0",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-22",
+    "version": "1.0.8-20",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-22",
+    "version": "1.0.8-23",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.9",
+    "version": "1.0.8-22",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.9-0",
+    "version": "1.0.9",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-23",
+    "version": "1.0.8-21",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.8",
+    "version": "1.0.9-0",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "module": "./es/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/vueComponent/pro-layout"
+        "url": "https://github.com/hongjunshi/pro-layout"
     },
     "publishConfig": {
         "registry": "http://43.239.120.231:11381/repository/npm-hangar/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-22",
+    "version": "1.0.8-21",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-21",
+    "version": "1.0.8-22",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "eslint -c ./.eslintrc --fix --ext .jsx,.js,.vue ./src",
         "compile": "vc-tools run compile --babel-runtime",
         "test": "cross-env NODE_ENV=test jest --config .jest.js",
-        "prepublishOnly": "npm run lint && npm run test && npm run compile && np --no-cleanup --yolo --no-publish --no-release-draft"
+        "prepublishOnly": "npm run lint && npm run test && npm run compile && np --no-cleanup --yolo --no-publish"
     },
     "files": [
         "es",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-21",
+    "version": "1.0.8-20",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@hangar/pro-layout",
-    "version": "1.0.9",
+    "name": "@ant-design-vue/pro-layout",
+    "version": "1.0.8-20",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {
@@ -20,7 +20,7 @@
         "lint": "eslint -c ./.eslintrc --fix --ext .jsx,.js,.vue ./src",
         "compile": "vc-tools run compile --babel-runtime",
         "test": "cross-env NODE_ENV=test jest --config .jest.js",
-        "prepublishOnly": "npm run lint && npm run test && npm run compile && np --no-cleanup --yolo --no-publish"
+        "prepublishOnly": "npm run lint && npm run test && npm run compile && np --no-cleanup --yolo --no-publish --no-release-draft"
     },
     "files": [
         "es",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.9-0",
+    "version": "1.0.8-21",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/vueComponent/pro-layout"
+    },
+    "publishConfig": {
+        "registry": "http://43.239.120.231:11381/repository/npm-hangar/"
     },
     "contributors": [
         "tangjinzhou <415800467@qq.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.8-21",
+    "version": "1.0.8-22",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-22",
+    "name": "@hangar/pro-layout",
+    "version": "1.0.9",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.10",
+    "version": "1.0.8",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ant-design-vue/pro-layout",
-    "version": "1.0.8-20",
+    "version": "1.0.8-21",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hangar/pro-layout",
-    "version": "1.0.8-22",
+    "version": "1.0.9",
     "main": "./lib/index.js",
     "module": "./es/index.js",
     "repository": {

--- a/src/components/RouteMenu/BasciMenu.less
+++ b/src/components/RouteMenu/BasciMenu.less
@@ -1,0 +1,18 @@
+@import "~ant-design-vue/es/style/themes/default";
+
+@badge-menu-item-prefix-cls: ~'@{ant-prefix}-pro-badge-menu-item';
+
+.@{badge-menu-item-prefix-cls} {
+  .ant-badge {
+    width: 100%;
+
+    &:hover > a {
+      color: @white;
+      cursor: pointer;
+    }
+
+    a {
+      color: rgba(255, 255, 255, 0.65);
+    }
+  }
+}

--- a/src/components/RouteMenu/BasciMenu.less
+++ b/src/components/RouteMenu/BasciMenu.less
@@ -2,23 +2,61 @@
 
 @badge-menu-item-prefix-cls: ~'@{ant-prefix}-pro-badge-menu-item';
 
+.ant-menu-horizontal, .ant-menu-dark {
+  .@{badge-menu-item-prefix-cls} {
+    .ant-badge {
+
+      &:hover > a {
+        color: @white;
+      }
+
+      a {
+        color: rgba(255, 255, 255, 0.65);
+      }
+    }
+  }
+}
+.ant-menu-light {
+  .@{badge-menu-item-prefix-cls} {
+    .ant-badge {
+
+      &:hover > a {
+        color: @primary-color;
+      }
+
+      .router-link-exact-active {
+        color: @primary-color;
+      }
+    }
+  }
+}
+
 .@{badge-menu-item-prefix-cls} {
   .ant-badge {
     width: 100%;
-    line-height: 1;
+    line-height: unset;
     vertical-align: baseline;
+    display: block;
 
     &:hover > a {
-      color: @white;
       cursor: pointer;
+      display: block;
     }
 
-    a {
-      color: rgba(255, 255, 255, 0.65);
+    a::before {
+      position: absolute;
+      top: 0;
+      right: -16px;
+      bottom: 0;
+      left: 0;
+      background-color: transparent;
+      content: '';
+      z-index: 1000;
     }
 
     .ant-badge-dot, .ant-badge-count {
       box-shadow: none;
+      top: 15px;
     }
   }
 }

--- a/src/components/RouteMenu/BasciMenu.less
+++ b/src/components/RouteMenu/BasciMenu.less
@@ -5,6 +5,8 @@
 .@{badge-menu-item-prefix-cls} {
   .ant-badge {
     width: 100%;
+    line-height: 1;
+    vertical-align: baseline;
 
     &:hover > a {
       color: @white;

--- a/src/components/RouteMenu/BasciMenu.less
+++ b/src/components/RouteMenu/BasciMenu.less
@@ -16,5 +16,9 @@
     a {
       color: rgba(255, 255, 255, 0.65);
     }
+
+    .ant-badge-dot, .ant-badge-count {
+      box-shadow: none;
+    }
   }
 }

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -45,6 +45,7 @@ const renderSubMenu = (h, item, i18nRender) => {
 
 const renderMenuItem = (h, item, i18nRender) => {
   const meta = Object.assign({}, item.meta)
+  const badge = Object.assign({}, item.meta.badge)
   const target = meta.target || null
   const hasRemoteUrl = httpReg.test(item.path)
   const CustomTag = target && 'a' || 'router-link'
@@ -58,10 +59,11 @@ const renderMenuItem = (h, item, i18nRender) => {
       cd.meta = Object.assign(cd.meta || {}, { hidden: true })
     })
   }
+  const badgeColor = badge.count === undefined ? badge.color : null
   return (
     <MenuItem key={item.path} class="ant-pro-badge-menu-item">
       {meta.showBadge ? (
-        <a-badge count={meta.badgeCount}>
+        <a-badge count={badge.count} dot={badge.count === undefined} color={badgeColor}>
           <CustomTag {...{ props, attrs }}>
             {renderIcon(h, meta.icon)}
             {renderTitle(h, meta.title, i18nRender)}

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -44,8 +44,27 @@ const renderSubMenu = (h, item, i18nRender) => {
 }
 
 const renderMenuItem = (h, item, i18nRender) => {
+  return (
+    <MenuItem key={item.path} class="ant-pro-badge-menu-item">
+      {item.meta.showBadge ? renderBadgeMenuItem(h, item, i18nRender) : renderMenuItemTag(h, item, i18nRender)}
+    </MenuItem>
+  )
+}
+
+const renderBadgeMenuItem = (h, item, i18nRender) => {
+  let badge = Object.assign({}, item.meta.badge)
+  if (!badge.count && !badge.color) {
+    badge.color = '#f5222d'
+  }
+  return (
+    <a-badge {...{ props: badge }}>
+      {renderMenuItemTag(h, item, i18nRender)}
+    </a-badge>
+  )
+}
+
+const renderMenuItemTag = (h, item, i18nRender) => {
   const meta = Object.assign({}, item.meta)
-  const badge = Object.assign({}, item.meta.badge)
   const target = meta.target || null
   const hasRemoteUrl = httpReg.test(item.path)
   const CustomTag = target && 'a' || 'router-link'
@@ -59,23 +78,11 @@ const renderMenuItem = (h, item, i18nRender) => {
       cd.meta = Object.assign(cd.meta || {}, { hidden: true })
     })
   }
-  const badgeColor = badge.count === undefined ? badge.color : null
   return (
-    <MenuItem key={item.path} class="ant-pro-badge-menu-item">
-      {meta.showBadge ? (
-        <a-badge count={badge.count} dot={badge.count === undefined} color={badgeColor}>
-          <CustomTag {...{ props, attrs }}>
-            {renderIcon(h, meta.icon)}
-            {renderTitle(h, meta.title, i18nRender)}
-          </CustomTag>
-        </a-badge>
-        ) : (
-        <CustomTag {...{ props, attrs }}>
-          {renderIcon(h, meta.icon)}
-          {renderTitle(h, meta.title, i18nRender)}
-        </CustomTag>
-      )}
-    </MenuItem>
+    <CustomTag {...{ props, attrs }}>
+      {renderIcon(h, meta.icon)}
+      {renderTitle(h, meta.title, i18nRender)}
+    </CustomTag>
   )
 }
 

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -181,6 +181,17 @@ const RouteMenu = {
       }
 
       this.collapsed ? (this.cachedOpenKeys = openKeys) : (this.openKeys = openKeys)
+    },
+    calculatePadding() {
+      // TODO: 这里有更好的解决办法来修改伪类大小，用来覆盖元素大小
+      let itemArr = document.getElementsByClassName("ant-pro-badge-menu-item")
+      for (let i = 0; i < itemArr.length; i++) {
+        let paddingLeft = itemArr[i].style.paddingLeft
+        let domA = itemArr[i].querySelector('a')
+        let a = 'left:' + paddingLeft
+        console.log(a)
+        document.styleSheets[0].addRule('a::before',a)
+      }
     }
   },
   computed: {
@@ -205,6 +216,7 @@ const RouteMenu = {
   },
   mounted () {
     this.updateMenu()
+    // this.calculatePadding()
   }
 }
 

--- a/src/components/RouteMenu/BaseMenu.jsx
+++ b/src/components/RouteMenu/BaseMenu.jsx
@@ -59,11 +59,20 @@ const renderMenuItem = (h, item, i18nRender) => {
     })
   }
   return (
-    <MenuItem key={item.path}>
-      <CustomTag {...{ props, attrs }}>
-        {renderIcon(h, meta.icon)}
-        {renderTitle(h, meta.title, i18nRender)}
-      </CustomTag>
+    <MenuItem key={item.path} class="ant-pro-badge-menu-item">
+      {meta.showBadge ? (
+        <a-badge count={meta.badgeCount}>
+          <CustomTag {...{ props, attrs }}>
+            {renderIcon(h, meta.icon)}
+            {renderTitle(h, meta.title, i18nRender)}
+          </CustomTag>
+        </a-badge>
+        ) : (
+        <CustomTag {...{ props, attrs }}>
+          {renderIcon(h, meta.icon)}
+          {renderTitle(h, meta.title, i18nRender)}
+        </CustomTag>
+      )}
     </MenuItem>
   )
 }

--- a/src/components/RouteMenu/index.js
+++ b/src/components/RouteMenu/index.js
@@ -1,2 +1,3 @@
 import BaseMenu from './BaseMenu'
+import './BasciMenu.less'
 export default BaseMenu


### PR DESCRIPTION
1.表单Item增加Badge支持
2.调整打包发布内容, 名称修改为@hangar/pro-layout, 防止npm仓库非私服时, 会出现选择pro-layout版本的问题